### PR TITLE
Fix editor keybinding selector

### DIFF
--- a/keymaps/move-by-paragraph.cson
+++ b/keymaps/move-by-paragraph.cson
@@ -1,4 +1,4 @@
-'.atom-text-editor':
+'atom-text-editor':
   'alt-up': 'move-by-paragraph:move-to-previous-paragraph'
   'shift-alt-up': 'move-by-paragraph:select-to-previous-paragraph'
   'alt-down': 'move-by-paragraph:move-to-next-paragraph'


### PR DESCRIPTION
In Atom, `atom-text-editor` is the editor's tag name, not a class name
