### PR TITLE
Fix deprecations (and implement paragraph selection spec)

### DIFF
--- a/lib/move-by-paragraph.coffee
+++ b/lib/move-by-paragraph.coffee
@@ -1,12 +1,13 @@
 _ = require 'underscore-plus'
-{$$, Point, Range} = require 'atom'
+{$$} = require 'atom-space-pen-views'
+{Point, Range} = require 'atom'
 
 module.exports =
-  activate: (state) ->
-    atom.workspaceView.command "move-by-paragraph:move-to-next-paragraph", => @byParagraph('move', 'next')
-    atom.workspaceView.command "move-by-paragraph:select-to-next-paragraph", => @byParagraph('select', 'next')
-    atom.workspaceView.command "move-by-paragraph:move-to-previous-paragraph", => @byParagraph('move', 'previous')
-    atom.workspaceView.command "move-by-paragraph:select-to-previous-paragraph", => @byParagraph('select', 'previous')
+  activate: ->
+    atom.commands.add 'atom-workspace', 'move-by-paragraph:move-to-next-paragraph', => @byParagraph('move', 'next')
+    atom.commands.add 'atom-workspace', 'move-by-paragraph:select-to-next-paragraph', => @byParagraph('select', 'next')
+    atom.commands.add 'atom-workspace', 'move-by-paragraph:move-to-previous-paragraph', => @byParagraph('move', 'previous')
+    atom.commands.add 'atom-workspace', 'move-by-paragraph:select-to-previous-paragraph', => @byParagraph('select', 'previous')
 
   #
   # Shamelessly lifted from atom/vim-mode:
@@ -38,7 +39,7 @@ module.exports =
     editor.screenPositionForBufferPosition(position)
 
   byParagraph: (action, dir) ->
-    editor = atom.workspace.getActiveEditor()
+    editor = atom.workspace.getActiveTextEditor()
     return unless editor?
 
     dirs =

--- a/package.json
+++ b/package.json
@@ -3,18 +3,21 @@
   "main": "./lib/move-by-paragraph",
   "version": "1.1.0",
   "description": "Move by paragraphs",
-  "activationEvents": [
-    "move-by-paragraph:move-to-next-paragraph",
-    "move-by-paragraph:select-to-next-paragraph",
-    "move-by-paragraph:move-to-previous-paragraph",
-    "move-by-paragraph:select-to-previous-paragraph"
-  ],
+  "activationCommands": {
+    "atom-workspace": [
+      "move-by-paragraph:move-to-next-paragraph",
+      "move-by-paragraph:select-to-next-paragraph",
+      "move-by-paragraph:move-to-previous-paragraph",
+      "move-by-paragraph:select-to-previous-paragraph"
+    ]
+  },
   "repository": "https://github.com/karlin/move-by-paragraph",
   "license": "MIT",
   "engines": {
     "atom": "*"
   },
   "dependencies": {
-    "underscore-plus": "1.x"
+    "underscore-plus": "1.x",
+    "atom-space-pen-views": "^2.0.3"
   }
 }

--- a/spec/move-by-paragraph-spec.coffee
+++ b/spec/move-by-paragraph-spec.coffee
@@ -40,6 +40,21 @@ describe "MoveByParagraph", ->
       expect(editor.getCursorBufferPosition()).toEqual [1, 0]
 
     it "selects to the previous paragraph", ->
-      expect('to do')
+      editor.moveToBeginningOfLine()
+      atom.commands.dispatch editorElement, 'move-by-paragraph:select-to-next-paragraph'
+      expect(editor.getSelectedBufferRange()).toEqual [[0, 0], [1, 0]]
+      atom.commands.dispatch editorElement,
+      'move-by-paragraph:select-to-next-paragraph'
+      expect(editor.getSelectedBufferRange()).toEqual [[0, 0], [4, 0]]
+
     it "selects to the next paragraph", ->
-      expect('to do')
+      editor.moveToBeginningOfLine()
+      atom.commands.dispatch editorElement, 'move-by-paragraph:select-to-previous-paragraph'
+      expect(editor.getSelectedBufferRange()).toEqual [[0, 0], [0, 0]]
+      atom.commands.dispatch editorElement, 'move-by-paragraph:move-to-next-paragraph'
+      atom.commands.dispatch editorElement, 'move-by-paragraph:move-to-next-paragraph'
+      expect(editor.getCursorBufferPosition()).toEqual [4, 0]
+      atom.commands.dispatch editorElement, 'move-by-paragraph:select-to-previous-paragraph'
+      expect(editor.getSelectedBufferRange()).toEqual [[4, 0], [1, 0]]
+      atom.commands.dispatch editorElement, 'move-by-paragraph:select-to-previous-paragraph'
+      expect(editor.getSelectedBufferRange()).toEqual [[4, 0], [0, 0]]

--- a/spec/move-by-paragraph-spec.coffee
+++ b/spec/move-by-paragraph-spec.coffee
@@ -1,6 +1,3 @@
-# MoveByParagraph = require '../lib/move-by-paragraph'
-{WorkspaceView} = require 'atom'
-
 path = require 'path'
 # Use the command `window:run-package-specs` (cmd-alt-ctrl-p) to run specs.
 #
@@ -8,41 +5,38 @@ path = require 'path'
 # or `fdescribe`). Remove the `f` to unfocus the block.
 
 describe "MoveByParagraph", ->
-  [editor, editorView] = []
+  [editor, editorElement, workspaceElement] = []
 
   beforeEach ->
     runs ->
-      atom.workspaceView = new WorkspaceView
-      atom.workspaceView.openSync('sample.txt')
+      workspaceElement = atom.views.getView(atom.workspace)
 
-    runs ->
-      atom.workspaceView.attachToDom()
-      editorView = atom.workspaceView.getActiveView()
+    waitsForPromise ->
+      atom.workspace.open('sample.txt').then (ed) ->
+        editor = ed
+        editorElement = atom.views.getView(ed)
 
     waitsForPromise ->
       promise = atom.packages.activatePackage('move-by-paragraph')
-      atom.workspaceView.trigger 'move-by-paragraph:move-to-previous-paragraph'
+      atom.commands.dispatch workspaceElement, 'move-by-paragraph:move-to-previous-paragraph'
       promise
-
-    runs ->
-      {editor} = editorView
 
   describe "when the move-by-paragraph events are triggered", ->
     it "moves to the next paragraph", ->
-      editor.moveCursorToBeginningOfLine()
-      editorView.trigger 'move-by-paragraph:move-to-next-paragraph'
+      editor.moveToBeginningOfLine()
+      atom.commands.dispatch editorElement, 'move-by-paragraph:move-to-next-paragraph'
       expect(editor.getCursorBufferPosition()).toEqual [1, 0]
-      editorView.trigger 'move-by-paragraph:move-to-next-paragraph'
+      atom.commands.dispatch editorElement, 'move-by-paragraph:move-to-next-paragraph'
       expect(editor.getCursorBufferPosition()).toEqual [4, 0]
 
     it "moves to the previous paragraph", ->
-      editor.moveCursorToBeginningOfLine()
-      editorView.trigger 'move-by-paragraph:move-to-previous-paragraph'
+      editor.moveToBeginningOfLine()
+      atom.commands.dispatch editorElement, 'move-by-paragraph:move-to-previous-paragraph'
       expect(editor.getCursorBufferPosition()).toEqual [0, 0]
-      editorView.trigger 'move-by-paragraph:move-to-next-paragraph'
-      editorView.trigger 'move-by-paragraph:move-to-next-paragraph'
+      atom.commands.dispatch editorElement, 'move-by-paragraph:move-to-next-paragraph'
+      atom.commands.dispatch editorElement, 'move-by-paragraph:move-to-next-paragraph'
       expect(editor.getCursorBufferPosition()).toEqual [4, 0]
-      editorView.trigger 'move-by-paragraph:move-to-previous-paragraph'
+      atom.commands.dispatch editorElement, 'move-by-paragraph:move-to-previous-paragraph'
       expect(editor.getCursorBufferPosition()).toEqual [1, 0]
 
     it "selects to the previous paragraph", ->


### PR DESCRIPTION
This fixes all the deprecation warnings that Atom lists in the Deprecation Cop and in the package spec runner. I also implemented the specs for the `move-by-paragraph:select-to-previous-paragraph` and `move-by-paragraph:select-to-next-paragraph` commands.
